### PR TITLE
Fixed the installation of libyaml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,27 @@ project(FortYamlShackle Fortran C CXX)
 # Find the yaml module
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/tools/cmake/Modules")
 
-include(FetchContent) 
+include(ExternalProject)
 
-FetchContent_Declare(LibYaml
-	             GIT_REPOSITORY "https://github.com/yaml/libyaml"
-		     )
+# Set default ExternalProject root directory
+set(EXTERNALS_DIR ${CMAKE_BINARY_DIR}/ThirdParty)
 
-FetchContent_MakeAvailable(LibYaml)
-find_package(Yaml REQUIRED)
-include_directories(include ${YAML_INCLUDE_DIRS})
+# Add libyaml
+ExternalProject_Add(libyaml
+  PREFIX ${EXTERNALS_DIR}
+  GIT_REPOSITORY "https://github.com/yaml/libyaml"
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${EXTERNALS_DIR}/installed
+
+  # Log output
+  LOG_DOWNLOAD ON
+  LOG_CONFIGURE ON
+  LOG_BUILD ON
+  LOG_INSTALL ON
+)
+
+# Specify include dir
+include_directories(include ${EXTERNALS_DIR}/installed/include)
+
 add_subdirectory(src)
 install (FILES ${CMAKE_BINARY_DIR}/src/fortBinding 
  	 PERMISSIONS  GROUP_READ GROUP_EXECUTE 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,4 +3,6 @@ add_executable(fortBinding
 	       yamlEventReader.cpp
 	       )
 
-target_link_libraries(fortBinding ${YAML_LIBRARIES})
+add_dependencies(fortBinding libyaml)
+
+target_link_libraries(fortBinding ${EXTERNALS_DIR}/installed/lib/libyaml.a)

--- a/tools/cmake/Modules/FindYaml.cmake
+++ b/tools/cmake/Modules/FindYaml.cmake
@@ -46,6 +46,7 @@ else()
 
   find_path(YAML_INCLUDE_DIRS yaml.h)
   if(YAML_INCLUDE_DIRS)
+    message(STATUS "YAML_INCLUDE_DIRS: ${YAML_INCLUDE_DIRS}")
   else()
     set(YAML_FOUND FALSE)
   endif()


### PR DESCRIPTION
Used ExternalProject. No longer uses FindYaml.cmake, but I've
left it in case we want to interface with a system libyaml.
Spack is the future!